### PR TITLE
New feature: optionally hiding the menubar

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -20,6 +20,8 @@ ApplicationWindow {
     ExclusiveGroup { id: languageSettingsGroup }
 
     menuBar: MenuBar {
+        __contentItem.visible: settings.value("showMenu", true) === "true" ? true : false
+
         Menu {
             title: qsTr("File")
             MenuItem {
@@ -36,6 +38,16 @@ ApplicationWindow {
 
         Menu {
             title: qsTr("Settings")
+            MenuItem {
+                text: qsTr("Show Menu")
+                shortcut: "Ctrl+M"
+                checkable: true
+                checked: settings.value("showMenu", true) === "true" ? true : false
+                onToggled: {
+                    settings.setValue("showMenu", checked);
+                    menuBar.__contentItem.visible = checked
+                }
+            }
             Menu {
                 title: qsTr("Labeling")
                 MenuItem {


### PR DESCRIPTION
I think the menus on the menubar are not absolutely necessary:
1. File: we have "new game" button already.
2. Settings->Labeling: Most people play the default 2048 label.
3. Settings->Language: People won't touch it, it should be auto-selected by locale configuration.
4. Help: not very important.

so hiding the menubar won't do any harm and can lead to a clean UI.
