### PR TITLE
dont set the x, y coords of the window

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -13,9 +13,6 @@ ApplicationWindow {
     title: qsTr("2048 Game");
 //    flags: Qt.Window | Qt.WindowTitleHint  | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint
 
-    x: (Screen.width - width) / 2
-    y: (Screen.height - height) / 2
-
     ExclusiveGroup { id: labelSettingsGroup }
     ExclusiveGroup { id: languageSettingsGroup }
 


### PR DESCRIPTION
Fixes #17 by not setting the X and Y coordinates of the window which allows the window to be dragged onto another monitor. 